### PR TITLE
ability to use junidecode with JPMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,10 @@ dependencies {
 
 jar {
   manifest {
-    attributes 'Main-Class': 'net.gcardone.junidecode.App'
+    attributes (
+        'Main-Class': 'net.gcardone.junidecode.App'
+        'Automatic-Module-Name': 'net.gcardone.junidecode'
+      )
   }
 }
 


### PR DESCRIPTION
When using Java Platform Module System (JPMS) you can only import classes if they are exported from the defined module and also required in your `module-info.java` file.
The easiest way to retrofit a library to be used with JPMS without changing or refactoring anything else is to add `Automatic-Module-Name` to the `MANIFEST.MF`.
Otherwise such library is unusable and inaccessible to JPMS code.
This PR will cause no harm to you and your lib but significantly improves the usability of it because otherwise JPMS users are locked out.

p.s. I hope this project is still alive and there is a chance to get this merged and to have a new release in maven central with this feature. Thank you very much in advance.